### PR TITLE
removed doubled up camera, renamed camera back to 'player_camera' and marked it as active again

### DIFF
--- a/source/scenes/main/world.tscn
+++ b/source/scenes/main/world.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://bdo7a0e5m3fli"]
+[gd_scene load_steps=13 format=3 uid="uid://bdo7a0e5m3fli"]
 
 [ext_resource type="Script" path="res://source/scenes/main/world.gd" id="1_d1use"]
 [ext_resource type="PackedScene" uid="uid://brerulorr60o5" path="res://source/scenes/main/tile_system.tscn" id="2_kwtms"]
@@ -77,19 +77,14 @@ grow_vertical = 2
 mouse_filter = 2
 texture = SubResource("PlaceholderTexture2D_ckjp2")
 
-[node name="train" parent="." instance=ExtResource("4_t50p6")]
-position = Vector2(480, 257)
-
-[node name="player_camera" parent="." instance=ExtResource("4_gs2qm")]
-unique_name_in_owner = true
-min_zoom_level = 0.2
-max_zoom_level = 10.0
-
 [node name="TrainSpeedHUD" parent="player_camera" instance=ExtResource("6_uckai")]
 offset_left = 607.0
 offset_top = 346.0
 offset_right = 607.0
 offset_bottom = 346.0
+
+[node name="train" parent="." instance=ExtResource("4_t50p6")]
+position = Vector2(480, 257)
 
 [node name="music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("6_4cdvx")


### PR DESCRIPTION
quick fix for camera being silly